### PR TITLE
Fix `time.clock()` deprecation

### DIFF
--- a/algorithms/viewshed_raster.py
+++ b/algorithms/viewshed_raster.py
@@ -229,7 +229,8 @@ class ViewshedRaster(QgsProcessingAlgorithm):
 
 # --------------------- analysis ----------------------   
 
-        start = time.clock();  report=[]
+        start = time.process_time()
+        report = []
 
         
         #for speed and convenience, use maximum sized window for all analyses
@@ -280,7 +281,7 @@ class ViewshedRaster(QgsProcessingAlgorithm):
         dem = None
 
         txt = ("\n Analysis time: " + str(
-                            round( (time.clock() - start
+            round((time.process_time() - start
                                     ) / 60, 2)) + " minutes."
               " \n.      RESULTS \n Point_ID, visible pixels, total pixels" )
         


### PR DESCRIPTION
Small fix, `time.clock()` is deprecated in python 3.8 (see https://bugs.python.org/issue36895)

the patch should be tested for older python versions