### PR TITLE
Applies LZW compression for GeoTIFF output. Fix #40

### DIFF
--- a/algorithms/modules/Raster.py
+++ b/algorithms/modules/Raster.py
@@ -460,7 +460,7 @@ class Raster:
             
             
             driver = gdal.GetDriverByName('GTiff')
-            ds = driver.Create(file_name, self.size[1], self.size[0], 1, dataFormat)
+            ds = driver.Create(file_name, self.size[1], self.size[0], 1, dataFormat, ['COMPRESS=LZW'])
             ds.SetProjection(self.crs)
             ds.SetGeoTransform(self.rst.GetGeoTransform())
 


### PR DESCRIPTION
Applies LZW compression for GeoTIFF output.

Fix https://github.com/zoran-cuckovic/QGIS-visibility-analysis/issues/40