### PR TITLE
Fix crash in QGIS 3.36: use enum QgsProcessingParameterNumber.Type

### DIFF
--- a/algorithms/viewshed_index.py
+++ b/algorithms/viewshed_index.py
@@ -104,7 +104,8 @@ class VisibilityIndex(QgsProcessingAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(
             self.REFRACTION,
             self.tr('Atmoshpheric refraction'),
-            1, 0.13, False, 0.0, 1.0))
+            QgsProcessingParameterNumber.Type.Double,
+            0.13, False, 0.0, 1.0))
         
 
         self.addParameter(

--- a/algorithms/viewshed_intervisibility.py
+++ b/algorithms/viewshed_intervisibility.py
@@ -110,7 +110,8 @@ class Intervisibility(QgsProcessingAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(
             self.REFRACTION,
             self.tr('Atmoshpheric refraction'),
-            1, 0.13, False, 0.0, 1.0))
+            QgsProcessingParameterNumber.Type.Double,
+            0.13, False, 0.0, 1.0))
         
 ##        
 ##        self.addParameter(QgsProcessingParameterEnum (

--- a/algorithms/viewshed_raster.py
+++ b/algorithms/viewshed_raster.py
@@ -106,7 +106,8 @@ class ViewshedRaster(QgsProcessingAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(
             self.REFRACTION,
             self.tr('Atmoshpheric refraction'),
-            1, 0.13, False, 0.0, 1.0))
+            QgsProcessingParameterNumber.Type.Double,
+            0.13, False, 0.0, 1.0))
         
         
 ##        self.addParameter(QgsProcessingParameterEnum (


### PR DESCRIPTION
Use enum QgsProcessingParameterNumber.Type instead of 0 or 1 for type in QgsProcessingParameterNumber to fix exception in QGIS 3.36

Fixes exceptions such as:
